### PR TITLE
Update isnan.h

### DIFF
--- a/source/vdrift/isnan.h
+++ b/source/vdrift/isnan.h
@@ -5,5 +5,5 @@
 	static bool isnan(double number) {  return (number != number);  }
 #else  // gcc, c++11
 	#include <cmath>
-	#define isnan(f)  std::isnan(f)
+	using std::isnan;
 #endif


### PR DESCRIPTION
Prevents error: ‘std::std’ has not been declared 8 , when compiling Debug build with gcc 11.2